### PR TITLE
idで検索する機能と例外処理を追加

### DIFF
--- a/src/main/java/com/example/nameservice/NameController.java
+++ b/src/main/java/com/example/nameservice/NameController.java
@@ -1,27 +1,34 @@
 package com.example.nameservice;
 
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
+import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Map;
 
 @RestController
 public class NameController {
 
-    private NameMapper nameMapper;
+    private NameService nameService;
 
-    public NameController(NameMapper nameMapper) {
-        this.nameMapper = nameMapper;
+    public NameController(NameService nameService) {
+        this.nameService = nameService;
     }
 
     @GetMapping("/names")
-
     public List<Name> findNames(@RequestParam(required = false) String startsWith) {
         if (startsWith != null) {
-            return nameMapper.findByNameStartingWith(startsWith);
+            return nameService.findByNameStartingWith(startsWith);
         } else {
-            return nameMapper.findAll();
+            return nameService.findAll();
         }
+    }
+
+    @GetMapping("/names/{id}")
+    public Name findNameById(@PathVariable int id) {
+        return nameService.findById(id);
     }
 }

--- a/src/main/java/com/example/nameservice/NameMapper.java
+++ b/src/main/java/com/example/nameservice/NameMapper.java
@@ -4,6 +4,7 @@ import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Select;
 
 import java.util.List;
+import java.util.Optional;
 
 @Mapper
 public interface NameMapper {
@@ -13,4 +14,7 @@ public interface NameMapper {
 
     @Select("SELECT * FROM names WHERE name LIKE CONCAT(#{prefix}, '%')")
     List<Name> findByNameStartingWith(String prefix);
+
+    @Select("SELECT * FROM names WHERE id = #{id}")
+    Optional<Name> findById(int id);
 }

--- a/src/main/java/com/example/nameservice/NameNotFoundException.java
+++ b/src/main/java/com/example/nameservice/NameNotFoundException.java
@@ -1,0 +1,16 @@
+package com.example.nameservice;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import java.time.ZonedDateTime;
+import java.util.Map;
+
+public class NameNotFoundException extends RuntimeException {
+
+    public NameNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/nameservice/NameService.java
+++ b/src/main/java/com/example/nameservice/NameService.java
@@ -1,0 +1,33 @@
+package com.example.nameservice;
+
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class NameService {
+
+    private NameMapper nameMapper;
+
+    public NameService(NameMapper nameMapper) {
+        this.nameMapper = nameMapper;
+    }
+
+    public List<Name> findAll() {
+        return nameMapper.findAll();
+    }
+
+    public List<Name> findByNameStartingWith(String prefix) {
+        return nameMapper.findByNameStartingWith(prefix);
+    }
+
+    public Name findById(int id) {
+        Optional<Name> name = this.nameMapper.findById(id);
+        if (name.isPresent()) {
+            return name.get();
+        } else {
+            throw new NameNotFoundException("Name not found");
+        }
+    }
+}

--- a/src/main/java/com/example/nameservice/NameService.java
+++ b/src/main/java/com/example/nameservice/NameService.java
@@ -24,10 +24,6 @@ public class NameService {
 
     public Name findById(int id) {
         Optional<Name> name = this.nameMapper.findById(id);
-        if (name.isPresent()) {
-            return name.get();
-        } else {
-            throw new NameNotFoundException("Name not found");
-        }
+        return name.orElseThrow(() -> new NameNotFoundException("name not found"));
     }
 }

--- a/src/main/java/com/example/nameservice/NameServiceExceptionHandler.java
+++ b/src/main/java/com/example/nameservice/NameServiceExceptionHandler.java
@@ -1,0 +1,25 @@
+package com.example.nameservice;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.ZonedDateTime;
+import java.util.Map;
+
+@RestControllerAdvice
+public class NameServiceExceptionHandler {
+    @ExceptionHandler(NameNotFoundException.class)
+    public ResponseEntity<Map<String, String>> handleNameNotFoundException(
+            NameNotFoundException e, HttpServletRequest request) {
+        Map<String, String> body = Map.of(
+                "timestamp", ZonedDateTime.now().toString(),
+                "status", String.valueOf(HttpStatus.NOT_FOUND.value()),
+                "error", HttpStatus.NOT_FOUND.getReasonPhrase(),
+                "message", e.getMessage(),
+                "path", request.getRequestURI());
+        return new ResponseEntity(body, HttpStatus.NOT_FOUND);
+    }
+}


### PR DESCRIPTION
# idで名前を検索する機能と例外処理を追加  
## 概要
* 名前をidで検索できるように変更  
* リストにないidで検索した時例外処理を返すように変更  

## 動作確認

### リストにあるidで検索した結果 
ステータス200で動作することを確認
<img width="994" alt="スクリーンショット 2024-03-28 12 04 14" src="https://github.com/Gai-Tosaka/nameservice/assets/61763124/0a6e2bf8-bfdc-4b9c-9d4b-b84bb24304fb">
 
---

### リストにないidで検索した結果  
ステータス404でエラーを吐くことを確認
<img width="1010" alt="スクリーンショット 2024-03-28 12 00 48" src="https://github.com/Gai-Tosaka/nameservice/assets/61763124/0454a811-1e02-4b67-bfd9-eb12ea4a1f6e">
